### PR TITLE
remove whitespace from getCurrentVersion()

### DIFF
--- a/src/LaraUpdaterController.php
+++ b/src/LaraUpdaterController.php
@@ -199,7 +199,7 @@ class LaraUpdaterController extends Controller
     public function getCurrentVersion(){
         // todo: env file version
         $version = File::get(base_path().'/version.txt');
-        return $version;
+        return trim($version);
     }
 
     /*


### PR DESCRIPTION
getCurrentVersion() reported <code>1.0.2&nbsp;</code> instead of `1.0.2`. Notice the trailing whitespace.
This created a problem in `/updater.check` endpoint in which it returned `1.0.2`, although, the application was on `1.0.2` already.

--
Edit
Obviously, it is a unix/linux thing. Programs append a newline while saving the `.txt`.
The `trim()` command does the job though.