### PR TITLE
Update new zip function and new feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-## Author
+## Author and Contributor
 
-- **Pietro Cinaglia** - Contact me using [GitHub](https://github.com/pietrocinaglia) or [LinkedIn](https://linkedin.com/in/pietrocinaglia)
+- **Pietro Cinaglia** - Original Author - Contact using [GitHub](https://github.com/pietrocinaglia) or [LinkedIn](https://linkedin.com/in/pietrocinaglia)
+
+- **Aura Komputer** - Contact using [GitHub](https://github.com/aurakomputer)
 
 # LaraUpdater [ self-update for your Laravel App ]
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Author
-* **Pietro Cinaglia** - Contact me using [GitHub](https://github.com/pietrocinaglia) or [LinkedIn](https://linkedin.com/in/pietrocinaglia)
 
+- **Pietro Cinaglia** - Contact me using [GitHub](https://github.com/pietrocinaglia) or [LinkedIn](https://linkedin.com/in/pietrocinaglia)
 
 # LaraUpdater [ self-update for your Laravel App ]
 
@@ -14,30 +14,40 @@ WITHOUT LaraUpdate => Do you want to contact them one by one and send them the u
 
 #### WITH LaraUpdater => Let your application (ALONE) detects that a new update is available and notifies its presence to the administrator; furthermore, let your application install it and handles all related steps.
 
-
 ### NEW VERSION change-log
+
 - Now it can run from artisan command
 - Now it supports Laravel 8 and 9;
 - New view based on Bootstrap 5;
 - Bugs Fix.
 
+**3-2023**
+
+- Support laravel 10
+- Support ^php 8.0
+- break: move main() function in upgrade.php and use beforeUpdate() and afterUpdate() functionn
 
 ## Features:
 
 #### > Self-Update
+
 LaraUpdater allows your Laravel Application to self-update :)
 Let your application (ALONE) detects that a new update is available and notifies its presence to the administrator; furthermore, let your application install it and handles all related steps.
 
 #### > Maintenance Mode
+
 LaraUpdate activates the maintenance mode (using the native Laravel command) since the update starts until it finishes with success.
 
 #### > Security
-You can set which users  (e.g. only the admin) can perform an update for the application; this parameter is stored in the `config/laraupdater.php` so each application can sets its users indipendently. Furthermore, LaraUpdater is compatible with Laravel-Auth.
+
+You can set which users (e.g. only the admin) can perform an update for the application; this parameter is stored in the `config/laraupdater.php` so each application can sets its users indipendently. Furthermore, LaraUpdater is compatible with Laravel-Auth.
 
 #### > Fault tolerant
+
 During the update LaraUpdate BACKUPS all files that are overwritten, so if an error occurs it can try to restore automatically the previous state. If the restoring fails, you can use the backup stored in the root of your system for a manual maintenance.
 
 #### > Supports PHP script
+
 LaraUpdate can import a PHP script to perform custom actions (e.g. create a table in database after the update); the commands are performed in the last step of update.
 
 #### > Backup/Recovery Integrated
@@ -45,7 +55,6 @@ LaraUpdate can import a PHP script to perform custom actions (e.g. create a tabl
 #### > Multi-language
 
 #### > Access from web interface or console
-
 
 ## Getting Started
 
@@ -56,11 +65,11 @@ These instructions will get you a copy of the project up and running on your ser
 LaraUpdater has been tested using Laravel 8/9
 Recommended Laravel Version >= 8
 
-
 ## Installing
 
 This package can be installed through Composer:
-```
+
+```sh
 composer require pcinaglia/laraupdater
 ```
 
@@ -76,9 +85,10 @@ After installation you must perform these steps:
 ```
 
 #### 2) publish LaraUpdater in your app
+
 This step will copy the config file in the config folder of your Laraver App.
 
-```
+```sh
 php artisan vendor:publish --provider="pcinaglia\laraupdater\LaraUpdaterServiceProvider"
 ```
 
@@ -115,57 +125,69 @@ When it is published you can manage the configuration of LaraUpdater through the
 ```
 
 #### 3) Create version.txt
+
 To store current version of your application you have to create a text file named `version.txt` and copy it in the main folder of your Laravel App.
 For example, create a .txt file that contains only:
+
 ```
 1.0
 ```
+
 Use only 1 row, the first, of the .txt file.
 When release an update this files is updated from LaraUpdate.
-
 
 ## Create your update "repository"
 
 #### 1) Create the Archive
+
 Create a .zip archive with all files that you want replace during the update (use the same structure of your application to organize the files in the archive).
 
 #### 1.1) Upgrade Script (optional)
+
 You can create a PHP file named `upgrade.php` to perform custom actions (e.g. create a new table in the database).
-This file must contain a function named `main()` with a boolean return (to pass the status of its execution to LaraUpdater), see this example:
-```
+This file must contain a function named `beforeUpdate()` and `afterUpdate()` with a boolean return (to pass the status of its execution to LaraUpdater), see this example:
+
+```php
 <?php
 
-function main(){
-
-	example:
-        command-1-to-connect-db
-	    command-2-to-create-table
-	    command-3-to-insert-data
-
-	return true;
+function beforeUpdate(): bool
+{
+    Artisan::call('backup::db');
+    return true;
 }
+
+
+function afterUpdate(): bool
+{
+    Artisan::call('migrate --force');
+    Artisan::call('db::seed');
+    Artisan::call('module::seed');
+
+    return true;
+}
+
 ?>
 ```
-Note that the above example does not handle any exceptions, so the status of its execution return always true (not recommended).
 
+Note that the above example does not handle any exceptions, so the status of its execution return always true (not recommended).
 
 #### 2) Set the Metadata for your Update:
 
 Create a file named `laraupdater.json` like this:
-```
+
+```json
 {
-	"version": "1.0.2",
-	"archive": "RELEASE-1.02.zip",
-	"description": "Minor bugs fix"
+  "version": "1.0.2",
+  "archive": "RELEASE-1.02.zip",
+  "description": "Minor bugs fix"
 }
 ```
-`archive` contains the name for the .zip Archive (see Step-1).
 
+`archive` contains the name for the .zip Archive (see Step-1).
 
 #### 3) Upload your update
 
 Upload `laraupdater.json` and .zip Archive in the same folder of your server (the one that will host the update).
-
 
 #### 4) Configure your application
 
@@ -173,44 +195,44 @@ Set the server that will host the update in `config/laraupdater.php` (see Instal
 
 For example, if you upload files under:
 
-	http://yoursites.com/updatesformyapp/RELEASE-1.02.zip
-	and http://yoursites.com/updatesformyapp/laraupdater.json
+    http://yoursites.com/updatesformyapp/RELEASE-1.02.zip
+    and http://yoursites.com/updatesformyapp/laraupdater.json
 
 set `'update_baseurl'` as follows: `'update_baseurl' => 'http://yoursites.com/updatesformyapp',`
-
 
 ## Usage
 
 LaraUpdater implements three main methods that you can call using the web routes or artisan command:
 
 #### updater.check, laraupdater:check
+
 Returns '' (an update not exist) OR $version (e.g. 1.0.2, if an update exist).
 
 #### updater.currentVersion, laraupdater:current-version
+
 Returns the current version of your App (from `version.txt`).
 
 #### updater.update, laraupdater:update
+
 It downloads and installs the last update available.
 This web route is protected using the information under `'allow_users_id'` in `config/laraupdater.php`
 
 I suggest, to not use directly these routes BUT to show an Alert when an update is available; the Alert could be contain a Button to perform the update, see the solution below:
-
 
 ### Notification popup by using Bootstrap 5 and JQuery (included)
 
 ![alt text](readme_files/preview1.png "Alert with Update Button")
 
 Add to `resources/view/layout/app.blade.php` this code to load the view included in LaraUpdater (I suggest immediately before of `@yield('content')`):
+
 ```
 @include('vendor.laraupdater.notification')
 ```
 
 TEST: publish an update and refresh the page to show the alert :-)
 
-
 ## License
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
 
 (MIT License - WARRANTY Info) THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,8 @@
     ],
     "homepage": "https://github.com/pietrocinaglia/laraupdater",
     "require": {
-        "php": ">=7.0.0"
+        "php": ">=7.0.0 || ^8.0",
+        "illuminate/support": "^8.28 || ^9.0 || ^10.0"
     },
     "license": "MIT",
     "authors": [
@@ -36,12 +37,11 @@
             "pcinaglia\\laraupdater\\": "src"
         }
     },
-    "extra":{
-                "laravel":{
-                    "providers":[
-                        "pcinaglia\\laraupdater\\LaraUpdaterServiceProvider"
-                    ]
-                }
+    "extra": {
+        "laravel": {
+            "providers": [
+                "pcinaglia\\laraupdater\\LaraUpdaterServiceProvider"
+            ]
+        }
     }
 }
-

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,11 @@
             "name": "Pietro Cinaglia",
             "homepage": "https://github.com/pietrocinaglia",
             "role": "Software Engineer."
+        },
+        {
+            "name": "Mohamad Supangat",
+            "homepage": "https://github.com/mohamad-supangat",
+            "role": "Software Engineer."
         }
     ],
     "minimum-stability": "dev",
@@ -39,3 +44,4 @@
                 }
     }
 }
+

--- a/config/laraupdater.php
+++ b/config/laraupdater.php
@@ -9,7 +9,7 @@ return [
     /*
     * Temporary folder to store update before to install it.
     */
-    'tmp_folder_name' => 'tmp',
+    'tmp_folder_name' => 'storage/app/laraupdater/tmp_update',
 
     /*
     * Script's filename called during the update.

--- a/config/laraupdater.php
+++ b/config/laraupdater.php
@@ -3,34 +3,34 @@
 * @author: Pietro Cinaglia
 * https://github.com/pietrocinaglia
 */
-	 
-	return [
 
-		/*
-		* Temporary folder to store update before to install it.
-		*/
-		'tmp_folder_name' => 'tmp',
+return [
 
-		/*
-		* Script's filename called during the update.
-		*/
-		'script_filename' => 'upgrade.php',
+    /*
+    * Temporary folder to store update before to install it.
+    */
+    'tmp_folder_name' => 'tmp',
 
-		/*
-		* URL where your updates are stored ( e.g. for a folder named 'updates', under http://site.com/yourapp ).
-		*/
-		'update_baseurl' => 'http://localhost:8888/update',
+    /*
+    * Script's filename called during the update.
+    */
+    'script_filename' => 'upgrade.php',
 
-		/*
-		* Set a middleware for the route: updater.update
-		* Only 'auth' NOT works (manage security using 'allow_users_id' configuration)
-		*/
-		'middleware' => ['web', 'auth'],
+    /*
+    * URL where your updates are stored ( e.g. for a folder named 'updates', under http://site.com/yourapp ).
+    */
+    'update_baseurl' => 'http://localhost:8888/update',
 
-		/*
-		* Set which users can perform an update; 
-		* This parameter accepts: ARRAY(user_id) ,or FALSE => for example: [1]  OR  [1,3,0]  OR  false
-		* Generally, ADMIN have user_id=1; set FALSE to disable this check (not recommended)
-		*/
-		'allow_users_id' => [1] 
-	];
+    /*
+    * Set a middleware for the route: updater.update
+    * Only 'auth' NOT works (manage security using 'allow_users_id' configuration)
+    */
+    'middleware' => ['web', 'auth'],
+
+    /*
+    * Set which users can perform an update;
+    * This parameter accepts: ARRAY(user_id) ,or FALSE => for example: [1]  OR  [1,3,0]  OR  false
+    * Generally, ADMIN have user_id=1; set FALSE to disable this check (not recommended)
+    */
+    'allow_users_id' => [1]
+];

--- a/src/Helpers/UpdateHelper.php
+++ b/src/Helpers/UpdateHelper.php
@@ -12,6 +12,12 @@ class UpdateHelper
     private $tmp_backup_dir = null;
     private $response_html = '';
 
+
+    private function initTmpBackupDir()
+    {
+        $this->tmp_backup_dir = storeage_path('app/laraupdater') . '/backup_' . date('Ymd');
+    }
+
     public function log($msg, $append_response = false, $type = 'info')
     {
         //Response HTML
@@ -225,7 +231,7 @@ class UpdateHelper
     private function backup($filename)
     {
         if (!isset($this->tmp_backup_dir)) {
-            $this->tmp_backup_dir = base_path() . '/backup_' . date('Ymd');
+            $this->initTmpBackupDir();
         }
 
         $backup_dir = $this->tmp_backup_dir;
@@ -247,8 +253,8 @@ class UpdateHelper
     {
         $this->log(trans("laraupdater.RECOVERY") . '<small>' . $e . '</small>', true, 'info');
 
-        if (!isset($this->tmp_backup_dir)) {
-            $this->tmp_backup_dir = base_path() . '/backup_' . date('Ymd');
+        if (!isset($this->tmp_backup_dir)) {;
+            $this->initTmpBackupDir();
             $this->log(trans("laraupdater.BACKUP_FOUND") . '<small>' . $this->tmp_backup_dir . '</small>', true, 'info');
         }
 

--- a/src/Helpers/UpdateHelper.php
+++ b/src/Helpers/UpdateHelper.php
@@ -82,6 +82,9 @@ class UpdateHelper
         } catch (\Exception $e) {
             $this->log(trans("laraupdater.EXCEPTION") . '<small>' . $e->getMessage() . '</small>', true, 'err');
             $this->recovery();
+
+            // up laravel after recovery on error
+            Artisan::call('up');
         }
     }
 

--- a/src/Helpers/UpdateHelper.php
+++ b/src/Helpers/UpdateHelper.php
@@ -15,7 +15,7 @@ class UpdateHelper
 
     private function initTmpBackupDir()
     {
-        $this->tmp_backup_dir = storeage_path('app/laraupdater') . '/backup_' . date('Ymd');
+        $this->tmp_backup_dir = storage_path('app/laraupdater') . '/backup_' . date('Ymd');
     }
 
     public function log($msg, $append_response = false, $type = 'info')
@@ -92,12 +92,13 @@ class UpdateHelper
             $update_script = base_path() . '/' . config('laraupdater.tmp_folder_name') . '/' . config('laraupdater.script_filename');
 
 
-            $zip = new ZipArchive();
+            $zip = new \ZipArchive();
             if ($zip->open($archive)) {
                 $archive = substr($archive, 0, -4);
 
                 // check if upgrade_scipr exist
                 $update_script_content = $zip->getFromName(config('laraupdater.script_filename'));
+                print($update_script_content);
                 if ($update_script_content) {
                     File::put($update_script, $update_script_content);
 

--- a/src/LaraUpdaterServiceProvider.php
+++ b/src/LaraUpdaterServiceProvider.php
@@ -17,7 +17,7 @@ class LaraUpdaterServiceProvider extends ServiceProvider
     public function boot()
     {
         $this->publishes([__DIR__ . '/../config/laraupdater.php' => config_path('laraupdater.php'),], 'laraupdater');
-        $this->publishes([__DIR__ . '/../lang' => resource_path('lang')], 'laraupdater');
+        $this->publishes([__DIR__ . '/../lang' => lang_path()], 'laraupdater');
         $this->publishes([__DIR__ . '/../views' => resource_path('views/vendor/laraupdater')], 'laraupdater');
 
         $this->loadRoutesFrom(__DIR__ . '/Http/routes.php');


### PR DESCRIPTION
the zip_open in php is deprecated since php 8.0
see https://www.php.net/manual/en/function.zip-open.php 

the new method can be used is using class ZipArchive
see: https://www.php.net/manual/en/ziparchive.open.php

- [x] update new zip function
- [x] add illuminate/support as dependencies since using with laravel
- [x] new lang target folder in laravel 10 https://laravel.com/docs/10.x/upgrade#language-directory
- [x] break: remove main function in upgrade.php and  create function to run upgrade.php with trigger beforeUpdate and afterUpdate function 