### PR TITLE
updater.check should return a version number

### DIFF
--- a/src/Helpers/UpdateHelper.php
+++ b/src/Helpers/UpdateHelper.php
@@ -229,7 +229,7 @@ class UpdateHelper
     {
         $last_version = $this->getLastVersion();
         if (version_compare($last_version['version'], $this->getCurrentVersion(), ">")) {
-            return $last_version;
+            return $last_version['version'];
         }
         return '';
     }


### PR DESCRIPTION
README states:
>updater.check, laraupdater:check
>Returns '' (an update not exist) OR $version (e.g. 1.0.2, if an update exist).

But the current ouput of `updater.check` when there is an update available is the whole JSON entry.